### PR TITLE
Rename linkedin_username to linkedin_url for clarity

### DIFF
--- a/ice_breaker.py
+++ b/ice_breaker.py
@@ -18,8 +18,8 @@ from output_parsers import (
 def ice_break_with(
     name: str,
 ) -> Tuple[Summary, TopicOfInterest, IceBreaker, str]:
-    linkedin_username = linkedin_lookup_agent(name=name)
-    linkedin_data = scrape_linkedin_profile(linkedin_profile_url=linkedin_username)
+    linkedin_url = linkedin_lookup_agent(name=name)
+    linkedin_data = scrape_linkedin_profile(linkedin_profile_url=linkedin_url)
 
     twitter_username = twitter_lookup_agent(name=name)
     tweets = scrape_user_tweets_mock(username=twitter_username)


### PR DESCRIPTION
Fixes #2

Renamed `linkedin_username` to `linkedin_url` in the `ice_break_with` function for better semantic clarity. The variable contains a URL, not just a username, making the new name more accurate.

Generated with [Claude Code](https://claude.ai/code)